### PR TITLE
Add Windows Phone 7 light theme toggle

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,12 +1,21 @@
 import 'react-app-polyfill/ie11'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { MacOsToggle, useToggle } from '../.'
+import { IosToggle, MacOsToggle, WindowsPhone, useToggle } from '../.'
 
 const App = () => {
   const [value, { toggle }] = useToggle()
+  const verticalDivider = <div style={{ display: 'inline-flex', width: 20 }} />
 
-  return <MacOsToggle onChange={toggle} value={value} />
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <MacOsToggle onChange={toggle} value={value} />
+      {verticalDivider}
+      <IosToggle onChange={toggle} value={value} />
+      {verticalDivider}
+      <WindowsPhone onChange={toggle} value={value} />
+    </div>
+  )
 }
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/BaseToggle.tsx
+++ b/src/BaseToggle.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { css, cx } from '@emotion/css'
 
+// @todo: Add SpanHtmlElement props to the ToggleProps
+// This type should be a union of custom toggle specific props and the built-in
+// props of a span (the root element of our toggle)
 export type ToggleProps = {
   value?: boolean
   activeColor?: React.CSSProperties['color']
@@ -37,7 +40,7 @@ const BaseToggle: React.FC<BaseToggleProps & ToggleProps> = ({
   toggleCss,
   onLabelCss,
   offLabelCss,
-  animationDuration,
+  animationDuration = 0.3,
   animationType = 'spring',
   beginAnimationX = 0,
   endAnimationX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as IosToggle } from './variants/IosToggle'
 export { default as MacOsToggle } from './variants/MacOsToggle'
+export { default as WindowsPhone } from './variants/WindowsPhone'
 export { default as useToggle } from './hooks/useToggle'

--- a/src/variants/WindowsPhone.tsx
+++ b/src/variants/WindowsPhone.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import BaseToggle, { ToggleProps } from '../BaseToggle'
+
+const switchWidth = 86
+const switchHeight = 33
+
+const toggleWidth = 20
+const toggleHeight = 37
+
+const duration = 0.3 // seconds
+const padding = 0
+
+const borderGap = 2
+
+const IosToggle: React.FC<ToggleProps> = ({ value, ...rest }) => {
+  return (
+    <BaseToggle
+      animationDuration={duration}
+      endAnimationX={switchWidth - toggleWidth}
+      trackCss={`
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+
+        width: ${switchWidth}px;
+        height: ${switchHeight}px;
+        padding: ${padding}px; 
+        box-shadow: inset 0 0 0 2px #ffffff;
+        border: 2px solid #000000;
+        border-radius: 0;
+        background-color: ${value ? '#2AA0E3' : '#fff'};
+      `}
+      toggleCss={`
+      box-sizing: border-box;
+      background-color: #ffffff;
+      display: flex;
+      height: ${toggleHeight}px;
+      width: ${toggleWidth}px;
+      border: ${borderGap}px solid #000;
+      border-radius: 0;
+      box-shadow: 0px 0px 0px ${borderGap}px #fff;
+      transition: box-shadow ${duration}s;
+      margin-left: -${borderGap}px;
+    `}
+      value={value}
+      {...rest}
+    />
+  )
+}
+
+export default IosToggle


### PR DESCRIPTION
In this PR I am attempting to recreate the original Windows Phone 7 toggle. There aren't many examples for light themed Windows Phone 7 on the web; this PR was partially based on this screenshot:

![pictures-screen-pictures-camera-settings](https://user-images.githubusercontent.com/11673029/110055302-bd1fac00-7d2a-11eb-9bdf-97230d7071b8.png)
 