### PR TITLE
Implement different sizes for the IosToggle

### DIFF
--- a/src/BaseToggle.tsx
+++ b/src/BaseToggle.tsx
@@ -2,11 +2,14 @@ import React, { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { css, cx } from '@emotion/css'
 
+export type ToggleSize = 'small' | 'medium' | 'large'
+
 // @todo: review the relevance of `activeColor` and `trackColor`
 export type ToggleProps = {
   on?: boolean
   activeColor?: React.CSSProperties['color']
   trackColor?: React.CSSProperties['color']
+  size?: ToggleSize
   onChange?: (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void
   textDirection?: 'ltr' | 'rtl'
 }

--- a/src/variants/IosToggle.tsx
+++ b/src/variants/IosToggle.tsx
@@ -1,11 +1,36 @@
 import React from 'react'
-import BaseToggle, { ToggleProps } from '../BaseToggle'
+import BaseToggle, { ToggleProps, ToggleSize } from '../BaseToggle'
 
-const theme = {
-  animation: {
-    duration: 0.3,
+type IosToggleDimention = {
+  track: {
+    width: number
+    height: number
+    borderRadius: number
+    padding: number
+  }
+  thumb: {
+    width: number
+    height: number
+    borderRadius: string
+  }
+}
+
+const dimensions: Record<ToggleSize, IosToggleDimention> = {
+  small: {
+    track: {
+      width: 59 / 1.2,
+      height: 39 / 1.2,
+      borderRadius: 40 / 1.2,
+      padding: 2 / 1.2,
+    },
+    thumb: {
+      width: 35 / 1.2,
+      height: 35 / 1.2,
+      borderRadius: '50%',
+    },
   },
-  dimensions: {
+
+  medium: {
     track: {
       width: 59,
       height: 39,
@@ -17,6 +42,27 @@ const theme = {
       height: 35,
       borderRadius: '50%',
     },
+  },
+
+  large: {
+    track: {
+      width: 59 * 1.4,
+      height: 39 * 1.4,
+      borderRadius: 40 * 1.4,
+      padding: 2 * 1.4,
+    },
+    thumb: {
+      width: 35 * 1.4,
+      height: 35 * 1.4,
+      borderRadius: '50%',
+    },
+  },
+}
+
+const theme = {
+  dimensions,
+  animation: {
+    duration: 0.3,
   },
   palette: {
     track: {
@@ -30,25 +76,25 @@ const theme = {
   },
 }
 
-const IosToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
+const IosToggle: React.FC<ToggleProps> = ({ on, size = 'medium', ...rest }) => {
   const { animation, dimensions, palette } = theme
 
   return (
     <BaseToggle
       animationDuration={animation.duration}
       endAnimationX={
-        dimensions.track.width -
-        dimensions.thumb.width -
-        dimensions.track.padding * 2
+        dimensions[size].track.width -
+        dimensions[size].thumb.width -
+        dimensions[size].track.padding * 2
       }
       trackCss={`
         box-sizing: border-box;
         display: inline-flex;
-        width: ${dimensions.track.width}px;
-        height: ${dimensions.track.height}px;
+        width: ${dimensions[size].track.width}px;
+        height: ${dimensions[size].track.height}px;
         align-items: center;
-        padding: ${dimensions.track.padding}px; 
-        border-radius: ${dimensions.track.borderRadius}px;
+        padding: ${dimensions[size].track.padding}px; 
+        border-radius: ${dimensions[size].track.borderRadius}px;
         transition: all ${animation.duration}s;
         transition-property: background-color, box-shadow;
         background-color: ${on ? palette.track.active : palette.track.inActive};
@@ -57,9 +103,9 @@ const IosToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
         box-sizing: border-box;
         background-color: ${palette.thumb.background};
         display: flex;
-        height: ${dimensions.thumb.height}px;
-        width: ${dimensions.thumb.width}px;
-        border-radius: ${dimensions.thumb.borderRadius};
+        height: ${dimensions[size].thumb.height}px;
+        width: ${dimensions[size].thumb.width}px;
+        border-radius: ${dimensions[size].thumb.borderRadius};
         transition: box-shadow ${animation.duration}s;
         box-shadow: ${palette.thumb.shadow};
       `}


### PR DESCRIPTION
A first attempt at creating different sizes for
toggles starting with the IosToggle.

* Adds a new prop size with possible values of: 'small' | 'medium' | 'large'
* Implement the 3 sizes for the IosToggle using eyeballed values