### PR TITLE
Use the term `switch` instead of `toggle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Styled Toggle
+# React Styled Switch
 
 <img src="demo.gif" alt="Demo" width="400"/>
 
@@ -8,9 +8,9 @@ recreate them using React.
 
 ### High level vision for this project
 
-A switch toggle in React using Emotion CSS, and Framer motion.
+A switch in React using Emotion CSS, and Framer motion.
 
-I want to evolve this to offer different toggle styles and allowing importing
+I want to evolve this to offer different switch styles and allowing importing
 only the style you want.
 
 Eventually, once I decide on the name and API, I will publish it as a standalone

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -2,15 +2,15 @@ import 'react-app-polyfill/ie11'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import {
-  IosToggle,
-  MacOsToggle,
-  WindowsPhoneToggle,
-  useToggle,
-  MaterialToggle,
+  IosSwitch,
+  MacOsSwitch,
+  WindowsPhoneSwitch,
+  useSwitch,
+  MaterialSwitch,
 } from '../.'
 
 const App = () => {
-  const [on, { toggle }] = useToggle()
+  const [on, { toggle }] = useSwitch()
   const props = {
     onChange: toggle,
     on,
@@ -27,10 +27,10 @@ const App = () => {
         columnGap: 20,
       }}
     >
-      <MacOsToggle {...props} />
-      <IosToggle {...props} />
-      <MaterialToggle {...props} />
-      <WindowsPhoneToggle {...props} />
+      <MacOsSwitch {...props} />
+      <IosSwitch {...props} />
+      <MaterialSwitch {...props} />
+      <WindowsPhoneSwitch {...props} />
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "styled-toggle",
+  "name": "react-styled-switch",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -39,16 +39,16 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "name": "styled-toggle",
+  "name": "react-styled-switch",
   "author": "Haïder Alshamma",
-  "module": "dist/styled-toggle.esm.js",
+  "module": "dist/styled-switch.esm.js",
   "size-limit": [
     {
-      "path": "dist/styled-toggle.cjs.production.min.js",
+      "path": "dist/styled-switch.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/styled-toggle.esm.js",
+      "path": "dist/styled-switch.esm.js",
       "limit": "10 KB"
     }
   ],

--- a/src/BaseToggle.tsx
+++ b/src/BaseToggle.tsx
@@ -2,19 +2,19 @@ import React, { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { css, cx } from '@emotion/css'
 
-export type ToggleSize = 'small' | 'medium' | 'large'
+export type SwitchSize = 'small' | 'medium' | 'large'
 
 // @todo: review the relevance of `activeColor` and `trackColor`
-export type ToggleProps = {
+export type SwitchProps = {
   on?: boolean
   activeColor?: React.CSSProperties['color']
   trackColor?: React.CSSProperties['color']
-  size?: ToggleSize
+  size?: SwitchSize
   onChange?: (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void
   textDirection?: 'ltr' | 'rtl'
 }
 
-type BaseToggleProps = {
+type BaseSwitchProps = {
   trackCss?: string
   thumbCss?: string
 
@@ -52,7 +52,7 @@ const defaultLabelsWrapperCss = `
   align-items: center;
 `
 
-const BaseToggle: React.FC<BaseToggleProps & ToggleProps> = ({
+const BaseSwitch: React.FC<BaseSwitchProps & SwitchProps> = ({
   on = false,
   // textDirection = 'ltr',
   onChange,
@@ -122,4 +122,4 @@ const BaseToggle: React.FC<BaseToggleProps & ToggleProps> = ({
   )
 }
 
-export default BaseToggle
+export default BaseSwitch

--- a/src/hooks/useToggle.tsx
+++ b/src/hooks/useToggle.tsx
@@ -1,15 +1,15 @@
 import { useMemo, useState } from 'react'
 
-type ToggleHandlers = {
+type SwitchHandlers = {
   setOn: () => void
   setOff: () => void
   toggle: () => void
   reset: () => void
 }
 
-const useToggle = (
+const useSwitch = (
   initialState: boolean = false
-): [boolean, ToggleHandlers] => {
+): [boolean, SwitchHandlers] => {
   const [state, setState] = useState<boolean>(initialState)
 
   const handlers = useMemo(
@@ -33,4 +33,4 @@ const useToggle = (
   return [state, handlers]
 }
 
-export default useToggle
+export default useSwitch

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export { default as useToggle } from './hooks/useToggle'
-export { default as BaseToggle } from './BaseToggle'
+export { default as useSwitch } from './hooks/useSwitch'
+export { default as BaseSwitch } from './BaseSwitch'
 
-export { default as IosToggle } from './variants/IosToggle'
-export { default as MacOsToggle } from './variants/MacOsToggle'
-export { default as WindowsPhoneToggle } from './variants/WindowsPhoneToggle'
-export { default as MaterialToggle } from './variants/MaterialToggle'
+export { default as IosSwitch } from './variants/IosSwitch'
+export { default as MacOsSwitch } from './variants/MacOsSwitch'
+export { default as WindowsPhoneSwitch } from './variants/WindowsPhoneSwitch'
+export { default as MaterialSwitch } from './variants/MaterialSwitch'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,12 @@
-import { ToggleProps } from './BaseToggle'
+import { SwitchProps } from './BaseSwitch'
 
 export const getCssSide = (
-  toggleState: 'on' | 'off',
-  direction: ToggleProps['textDirection'] = 'ltr'
+  switchState: 'on' | 'off',
+  direction: SwitchProps['textDirection'] = 'ltr'
 ) => {
   const config: Record<
     typeof direction,
-    Record<typeof toggleState, 'left' | 'right'>
+    Record<typeof switchState, 'left' | 'right'>
   > = {
     ltr: {
       on: 'left',
@@ -18,5 +18,5 @@ export const getCssSide = (
     },
   }
 
-  return config[direction][toggleState]
+  return config[direction][switchState]
 }

--- a/src/variants/IosToggle.tsx
+++ b/src/variants/IosToggle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import BaseToggle, { ToggleProps, ToggleSize } from '../BaseToggle'
+import BaseSwitch, { SwitchProps, SwitchSize } from '../BaseSwitch'
 
-type IosToggleDimention = {
+type IosSwitchDimention = {
   track: {
     width: number
     height: number
@@ -15,7 +15,7 @@ type IosToggleDimention = {
   }
 }
 
-const dimensions: Record<ToggleSize, IosToggleDimention> = {
+const dimensions: Record<SwitchSize, IosSwitchDimention> = {
   small: {
     track: {
       width: 59 / 1.2,
@@ -76,11 +76,11 @@ const theme = {
   },
 }
 
-const IosToggle: React.FC<ToggleProps> = ({ on, size = 'medium', ...rest }) => {
+const IosSwitch: React.FC<SwitchProps> = ({ on, size = 'medium', ...rest }) => {
   const { animation, dimensions, palette } = theme
 
   return (
-    <BaseToggle
+    <BaseSwitch
       animationDuration={animation.duration}
       endAnimationX={
         dimensions[size].track.width -
@@ -115,4 +115,4 @@ const IosToggle: React.FC<ToggleProps> = ({ on, size = 'medium', ...rest }) => {
   )
 }
 
-export default IosToggle
+export default IosSwitch

--- a/src/variants/MacOsToggle.tsx
+++ b/src/variants/MacOsToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import BaseToggle, { ToggleProps } from '../BaseToggle'
+import BaseSwitch, { SwitchProps } from '../BaseSwitch'
 import { getCssSide } from '../utils'
 
 const theme = {
@@ -34,14 +34,14 @@ const theme = {
 }
 
 const labelCss = (
-  toggleState: 'on' | 'off',
-  direction: ToggleProps['textDirection'] = 'ltr'
+  switchState: 'on' | 'off',
+  direction: SwitchProps['textDirection'] = 'ltr'
 ) => {
   const {
     dimensions: { thumb, track },
   } = theme
 
-  const side = getCssSide(toggleState, direction)
+  const side = getCssSide(switchState, direction)
 
   return `
     padding-${side}: ${(track.width - thumb.width - 2) / 4}px;
@@ -54,11 +54,11 @@ const labelCss = (
   `
 }
 
-const MacOsToggle: React.FC<ToggleProps> = ({ textDirection, on, ...rest }) => {
+const MacOsSwitch: React.FC<SwitchProps> = ({ textDirection, on, ...rest }) => {
   const { dimensions, palette, animation } = theme
 
   return (
-    <BaseToggle
+    <BaseSwitch
       animationDuration={animation.duration}
       endAnimationX={
         dimensions.track.width -
@@ -95,4 +95,4 @@ const MacOsToggle: React.FC<ToggleProps> = ({ textDirection, on, ...rest }) => {
   )
 }
 
-export default MacOsToggle
+export default MacOsSwitch

--- a/src/variants/MaterialToggle.tsx
+++ b/src/variants/MaterialToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import BaseToggle, { ToggleProps } from '../BaseToggle'
+import BaseSwitch, { SwitchProps } from '../BaseSwitch'
 
 const theme = {
   animation: {
@@ -34,11 +34,11 @@ const theme = {
   },
 }
 
-const MaterialToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
+const MaterialSwitch: React.FC<SwitchProps> = ({ on, ...rest }) => {
   const { animation, dimensions, palette } = theme
 
   return (
-    <BaseToggle
+    <BaseSwitch
       animationDuration={animation.duration}
       startAnimationX={-dimensions.thumb.width / 4}
       endAnimationX={
@@ -73,4 +73,4 @@ const MaterialToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
   )
 }
 
-export default MaterialToggle
+export default MaterialSwitch

--- a/src/variants/WindowsPhoneToggle.tsx
+++ b/src/variants/WindowsPhoneToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import BaseToggle, { ToggleProps } from '../BaseToggle'
+import BaseSwitch, { SwitchProps } from '../BaseSwitch'
 
 const theme = {
   animation: {
@@ -33,11 +33,11 @@ const theme = {
   },
 }
 
-const WindowsPhoneToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
+const WindowsPhoneSwitch: React.FC<SwitchProps> = ({ on, ...rest }) => {
   const { animation, dimensions, palette } = theme
 
   return (
-    <BaseToggle
+    <BaseSwitch
       animationDuration={animation.duration}
       endAnimationX={dimensions.track.width - dimensions.thumb.width}
       trackCss={`
@@ -67,4 +67,4 @@ const WindowsPhoneToggle: React.FC<ToggleProps> = ({ on, ...rest }) => {
   )
 }
 
-export default WindowsPhoneToggle
+export default WindowsPhoneSwitch

--- a/test/toggle.test.tsx
+++ b/test/toggle.test.tsx
@@ -2,24 +2,24 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import BaseToggle from '../src/BaseToggle'
+import BaseSwitch from '../src/BaseSwitch'
 
-describe('BaseToggle', () => {
+describe('BaseSwitch', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<BaseToggle />, div)
+    ReactDOM.render(<BaseSwitch />, div)
     ReactDOM.unmountComponentAtNode(div)
   })
 
   it('does not show labels when not passed `enableLabels` prop', () => {
-    const { queryByText } = render(<BaseToggle />)
+    const { queryByText } = render(<BaseSwitch />)
 
     expect(queryByText('on')).toBeNull()
     expect(queryByText('off')).toBeNull()
   })
 
   it('shows labels when passed `enableLabels` prop', () => {
-    const { queryByText } = render(<BaseToggle enableLabels />)
+    const { queryByText } = render(<BaseSwitch enableLabels />)
     expect(queryByText('Off')).toBeInTheDocument()
     expect(queryByText('On')).toBeInTheDocument()
   })
@@ -27,7 +27,7 @@ describe('BaseToggle', () => {
   it('shows the `onLabel` prop value when passed an `onLabel` prop', () => {
     const onLabel = 'foo'
     const { queryByText } = render(
-      <BaseToggle enableLabels onLabelText={onLabel} on={true} />
+      <BaseSwitch enableLabels onLabelText={onLabel} on={true} />
     )
 
     expect(queryByText(onLabel)).toBeDefined()
@@ -36,7 +36,7 @@ describe('BaseToggle', () => {
   it('shows the `offLabel` prop value when passed an `offLabel` prop', () => {
     const offLabel = 'foo'
     const { queryByText } = render(
-      <BaseToggle enableLabels offLabelText={offLabel} on={false} />
+      <BaseSwitch enableLabels offLabelText={offLabel} on={false} />
     )
 
     expect(queryByText(offLabel)).toBeDefined()


### PR DESCRIPTION
Initially I used the toggle, but it became
apparent to me with time that Switch is what most
libraries and interface guides use as a term to
describe this type of component.